### PR TITLE
Add standalone LLM microservice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install ruff black mypy setuptools_scm
+      - run: make lint
+
+  unit:
+    runs-on: ubuntu-24.04
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install . pytest
+      - run: make test
+
+  integration-mock:
+    runs-on: ubuntu-24.04
+    needs: unit
+    env:
+      USE_MOCK_LLM: '1'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install pytest httpx
+      - run: make ci
+
+  integration-real:
+    if: ${{ secrets.USE_REAL_LLM != '' }}
+    runs-on: [self-hosted, gpu]
+    needs: unit
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install pytest httpx docker
+      - run: make ci

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+.env
+*.pyc
+.mypy_cache/
+ruff_cache/
+*.egg-info/
+/.venv/
+/models/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+### Added
+- First release of independent LLM micro-service using vLLM.
+- Breaking change vs previous in-app LLM.
+- Migration guide forthcoming.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: lint test ci
+
+lint:
+	ruff check src tests
+	black --check src tests
+	mypy src
+
+test:
+	pytest -m "not integration"
+
+ci: lint test
+	pytest

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# LLM Microservice

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: "3.9"
+services:
+  external-llm:
+    build: ./docker
+    runtime: nvidia
+    environment:
+      NVIDIA_VISIBLE_DEVICES: all
+      MODEL_NAME: meta-llama/Meta-Llama-3-8B-Instruct
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      retries: 3

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,20 @@
+FROM nvidia/cuda:12.4.0-runtime-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    python3.11 python3.11-venv python3-pip curl git && \
+    rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y tini && rm -rf /var/lib/apt/lists/*
+
+ENV PYTHONUNBUFFERED=1 \
+    HF_HOME=/models/.cache
+
+RUN pip3 install --no-cache-dir fastapi uvicorn[standard] vllm huggingface-hub httpx
+
+WORKDIR /app
+COPY . /app
+
+RUN pip3 install --no-cache-dir .[server]
+
+CMD ["tini", "-g", "uvicorn", "llm_microservice.server.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docs/adr/0001-record-architecture.md
+++ b/docs/adr/0001-record-architecture.md
@@ -1,0 +1,3 @@
+# ADR 0001
+
+Initial architecture for LLM microservice using vLLM and FastAPI.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,11 @@
+# Architecture
+
+```plantuml
+@startuml
+actor Client
+package "LLM Microservice" {
+  [FastAPI Server] --> [vLLM Engine]
+}
+Client --> [FastAPI Server]
+@enduml
+```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,11 @@
+# Quickstart
+
+## Run with GPU
+```bash
+docker compose up -d
+```
+
+## Run without GPU (mock)
+```bash
+USE_MOCK_LLM=1 pytest -k integration
+```

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,0 +1,10 @@
+# SDK Usage
+
+```python
+from llm_microservice.sdk import LLMClient, CompletionRequest, ChatMessage
+
+client = LLMClient(base_url="http://localhost:8000")
+req = CompletionRequest(model="meta-llama/Meta-Llama-3-8B-Instruct", messages=[ChatMessage(role="user", content="Hi")])
+resp = client.chat_completions(req)
+print(resp.choices[0].message.content)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,8 @@
+site_name: LLM Microservice
+nav:
+  - Quickstart: quickstart.md
+  - Architecture: architecture.md
+  - SDK: sdk.md
+  - ADRs:
+      - ADR 0001: adr/0001-record-architecture.md
+docs_dir: docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,46 @@
+[build-system]
+requires = ["setuptools>=65", "wheel", "setuptools_scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "llm_microservice"
+dynamic = ["version"]
+requires-python = ">=3.11"
+license = {file = "LICENSE"}
+description = "LLM microservice with vLLM"
+readme = "README.md"
+
+[project.optional-dependencies]
+server = [
+    "fastapi",
+    "uvicorn[standard]",
+    "vllm",
+]
+
+[tool.setuptools_scm]
+write_to = "src/llm_microservice/_version.py"
+
+[tool.black]
+line-length = 88
+
+
+
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "B"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+mypy_path = "src"
+ignore_missing_imports = true
+plugins = ["pydantic.mypy"]
+
+[project.urls]
+Homepage = "https://example.com"
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+pythonpath = ["src"]

--- a/src/llm_microservice/sdk/__init__.py
+++ b/src/llm_microservice/sdk/__init__.py
@@ -1,0 +1,18 @@
+from .client import LLMClient, AsyncLLMClient
+from .models import (
+    ChatMessage,
+    CompletionRequest,
+    CompletionResponse,
+    CompletionChoice,
+    UsageInfo,
+)
+
+__all__ = [
+    "LLMClient",
+    "AsyncLLMClient",
+    "ChatMessage",
+    "CompletionRequest",
+    "CompletionResponse",
+    "CompletionChoice",
+    "UsageInfo",
+]

--- a/src/llm_microservice/sdk/client.py
+++ b/src/llm_microservice/sdk/client.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Optional
+
+import httpx
+
+from .models import CompletionRequest, CompletionResponse
+
+
+def _build_headers(api_key: Optional[str]) -> Dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
+class AsyncLLMClient:
+    def __init__(self, base_url: str, api_key: Optional[str] = None) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._client = httpx.AsyncClient(
+            timeout=httpx.Timeout(connect=2.0, read=30.0),
+            headers=_build_headers(api_key),
+        )
+
+    async def _post(self, path: str, data: Dict[str, Any]) -> httpx.Response:
+        for _ in range(3):
+            try:
+                return await self._client.post(f"{self._base_url}{path}", json=data)
+            except httpx.HTTPError:
+                await asyncio.sleep(0.5)
+        raise httpx.HTTPError("Failed after retries")
+
+    async def chat_completions(self, req: CompletionRequest) -> CompletionResponse:
+        resp = await self._post("/v1/chat/completions", req.model_dump())
+        resp.raise_for_status()
+        return CompletionResponse.model_validate(resp.json())
+
+    async def completions(self, req: CompletionRequest) -> CompletionResponse:
+        resp = await self._post("/v1/completions", req.model_dump())
+        resp.raise_for_status()
+        return CompletionResponse.model_validate(resp.json())
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+
+class LLMClient:
+    def __init__(self, base_url: str, api_key: Optional[str] = None) -> None:
+        self._async = AsyncLLMClient(base_url, api_key)
+
+    def chat_completions(self, req: CompletionRequest) -> CompletionResponse:
+        return asyncio.run(self._async.chat_completions(req))
+
+    def completions(self, req: CompletionRequest) -> CompletionResponse:
+        return asyncio.run(self._async.completions(req))
+
+    def close(self) -> None:
+        asyncio.run(self._async.aclose())

--- a/src/llm_microservice/sdk/models.py
+++ b/src/llm_microservice/sdk/models.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+from pydantic import BaseModel
+
+
+class ChatMessage(BaseModel):
+    role: str
+    content: str
+
+
+class CompletionRequest(BaseModel):
+    model: str
+    prompt: Optional[str] = None
+    messages: Optional[List[ChatMessage]] = None
+    max_tokens: Optional[int] = None
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    top_k: Optional[int] = None
+    repetition_penalty: Optional[float] = None
+    presence_penalty: Optional[float] = None
+    frequency_penalty: Optional[float] = None
+    logprobs: Optional[int] = None
+    stop: Optional[List[str] | str] = None
+    seed: Optional[int] = None
+    stream: bool = False
+
+
+class CompletionChoice(BaseModel):
+    index: int
+    message: ChatMessage
+    finish_reason: Optional[str] = None
+
+
+class UsageInfo(BaseModel):
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+
+
+class CompletionResponse(BaseModel):
+    id: str
+    object: str
+    created: int
+    model: str
+    choices: List[CompletionChoice]
+    usage: UsageInfo
+
+
+class LogProbResult(BaseModel):
+    token: str
+    logprob: float
+    top_logprobs: Optional[List[dict[str, Any]]] = None

--- a/src/llm_microservice/server/main.py
+++ b/src/llm_microservice/server/main.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import cast
+from typing import Callable, Awaitable
+import time
+from datetime import datetime
+from typing import Any, AsyncGenerator, Dict
+
+from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse, StreamingResponse, Response
+
+from ..sdk.models import (
+    ChatMessage,
+    CompletionRequest,
+    CompletionResponse,
+    CompletionChoice,
+    UsageInfo,
+)
+from ..utils import count_message_tokens, count_tokens
+
+try:
+    from vllm import LLM, SamplingParams
+except Exception:  # pragma: no cover - optional dependency
+    LLM = None
+    SamplingParams = None
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+MODEL_NAME = os.getenv("MODEL_NAME", "meta-llama/Meta-Llama-3-8B-Instruct")
+GPU_MEMORY_UTILIZATION = float(os.getenv("GPU_MEMORY_UTILIZATION", "0.85"))
+API_KEY = os.getenv("LLM_API_KEY")
+
+app = FastAPI()
+
+
+async def verify_auth(request: Request) -> None:
+    if API_KEY:
+        auth = request.headers.get("authorization")
+        if auth != f"Bearer {API_KEY}":
+            raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+AUTH_DEP = Depends(verify_auth)
+
+
+def log_middleware(app: FastAPI) -> None:
+    @app.middleware("http")
+    async def _log(
+        request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        start = time.time()
+        response = await call_next(request)
+        latency_ms = (time.time() - start) * 1000
+        data = {
+            "ts": datetime.utcnow().isoformat(),
+            "route": request.url.path,
+            "latency_ms": round(latency_ms, 2),
+            "prompt_tokens": getattr(request.state, "prompt_tokens", 0),
+            "completion_tokens": getattr(request.state, "completion_tokens", 0),
+            "model": getattr(request.state, "model_name", MODEL_NAME),
+        }
+        logger.info(json.dumps(data))
+        return response
+
+
+log_middleware(app)
+
+
+class LLMEngine:
+    def __init__(self) -> None:
+        if LLM is None:
+            raise RuntimeError("vLLM is not installed")
+        self.llm = LLM(
+            model=MODEL_NAME,
+            gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
+            max_model_len=16384,
+            quantization="awq",
+        )
+
+    def generate(self, prompt: str, params: SamplingParams) -> Any:
+        return self.llm.generate([prompt], params)[0]
+
+
+def get_engine() -> LLMEngine:
+    if not hasattr(app.state, "engine"):
+        app.state.engine = LLMEngine()
+    return cast(LLMEngine, app.state.engine)
+
+
+ENGINE_DEP = Depends(get_engine)
+
+
+@app.get("/health")
+async def health() -> Dict[str, str]:
+    return {"status": "ok"}
+
+
+async def _run_completion(
+    req: CompletionRequest,
+    engine: LLMEngine,
+) -> CompletionResponse:
+    prompt = req.prompt or "".join(m.content for m in req.messages or [])
+    sampling = SamplingParams(
+        n=1,
+        max_tokens=req.max_tokens,
+        temperature=req.temperature,
+        top_p=req.top_p,
+        top_k=req.top_k,
+        repetition_penalty=req.repetition_penalty,
+        presence_penalty=req.presence_penalty,
+        frequency_penalty=req.frequency_penalty,
+        stop=req.stop,
+        seed=req.seed,
+    )
+    result = engine.generate(prompt, sampling)
+    text = result.outputs[0].text
+    prompt_tokens = count_tokens(prompt)
+    completion_tokens = count_tokens(text)
+    choice = CompletionChoice(
+        index=0, message=ChatMessage(role="assistant", content=text)
+    )
+    return CompletionResponse(
+        id="cmpl-1",
+        object="chat.completion",
+        created=int(time.time()),
+        model=req.model,
+        choices=[choice],
+        usage=UsageInfo(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+        ),
+    )
+
+
+async def completion_endpoint(
+    req: CompletionRequest, engine: LLMEngine
+) -> CompletionResponse:
+    resp = await _run_completion(req, engine)
+    return resp
+
+
+async def completion_stream(
+    req: CompletionRequest, engine: LLMEngine
+) -> AsyncGenerator[bytes, None]:
+    resp = await _run_completion(req, engine)
+    data = resp.model_dump()
+    yield json.dumps({"choices": data["choices"], "model": data["model"]}).encode()
+
+
+@app.post("/v1/chat/completions")
+async def chat_completions(
+    req: CompletionRequest,
+    request: Request,
+    engine: LLMEngine = ENGINE_DEP,
+    _: None = AUTH_DEP,
+) -> Any:
+    request.state.model_name = req.model
+    request.state.prompt_tokens = count_message_tokens(req.messages or [])
+    if req.stream:
+        return StreamingResponse(
+            completion_stream(req, engine), media_type="text/event-stream"
+        )
+    resp = await completion_endpoint(req, engine)
+    request.state.completion_tokens = resp.usage.completion_tokens
+    return JSONResponse(resp.model_dump())
+
+
+@app.post("/v1/completions")
+async def completions(
+    req: CompletionRequest,
+    request: Request,
+    engine: LLMEngine = ENGINE_DEP,
+    _: None = AUTH_DEP,
+) -> Any:
+    request.state.model_name = req.model
+    request.state.prompt_tokens = count_tokens(req.prompt or "")
+    if req.stream:
+        return StreamingResponse(
+            completion_stream(req, engine), media_type="text/event-stream"
+        )
+    resp = await completion_endpoint(req, engine)
+    request.state.completion_tokens = resp.usage.completion_tokens
+    return JSONResponse(resp.model_dump())
+
+
+def create_app() -> FastAPI:
+    return app
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/src/llm_microservice/utils.py
+++ b/src/llm_microservice/utils.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+
+def count_tokens(text: str) -> int:
+    """Naively count tokens using whitespace split."""
+    return len(text.split())
+
+
+def count_message_tokens(messages: Iterable[Any]) -> int:
+    contents = []
+    for m in messages:
+        if isinstance(m, dict):
+            contents.append(m.get("content", ""))
+        else:
+            contents.append(getattr(m, "content", ""))
+    return sum(count_tokens(c) for c in contents)

--- a/tests/integration/test_endpoints.py
+++ b/tests/integration/test_endpoints.py
@@ -1,0 +1,53 @@
+import os
+import shutil
+import subprocess
+import time
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.integration
+
+DOCKER_AVAILABLE = shutil.which("docker") is not None
+
+
+@pytest.fixture(scope="session")
+def llm_base_url() -> str:
+    if not DOCKER_AVAILABLE:
+        pytest.skip("docker not available")
+    if os.getenv("USE_MOCK_LLM") == "1":
+        url = "http://localhost:5001"
+        container = subprocess.Popen(
+            ["docker", "run", "--rm", "-p", "5001:80", "lambdatest/openai-mock:latest"]
+        )
+        time.sleep(5)
+        yield url
+        container.terminate()
+        container.wait()
+    else:
+        subprocess.run(["docker", "compose", "up", "-d"], check=True)
+        url = "http://localhost:8000"
+        for _ in range(30):
+            try:
+                r = httpx.get(f"{url}/health")
+                if r.status_code == 200:
+                    break
+            except Exception:
+                time.sleep(1)
+        yield url
+        subprocess.run(["docker", "compose", "down"], check=True)
+
+
+def test_health(llm_base_url: str) -> None:
+    r = httpx.get(f"{llm_base_url}/health")
+    assert r.status_code == 200
+
+
+def test_chat_completion(llm_base_url: str) -> None:
+    payload = {
+        "model": "test",
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 1,
+    }
+    r = httpx.post(f"{llm_base_url}/v1/chat/completions", json=payload)
+    assert r.status_code == 200

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,0 +1,26 @@
+import importlib
+
+import pytest
+from fastapi import Depends, FastAPI
+from starlette.testclient import TestClient
+
+
+@pytest.fixture
+def app_with_auth(monkeypatch):
+    monkeypatch.setenv("LLM_API_KEY", "secret")
+    module = importlib.reload(importlib.import_module("llm_microservice.server.main"))
+    test_app = FastAPI()
+
+    @test_app.get("/")
+    async def root(_: None = Depends(module.verify_auth)):
+        return {"ok": True}
+
+    return TestClient(test_app)
+
+
+def test_auth_required(app_with_auth):
+    client = app_with_auth
+    resp = client.get("/")
+    assert resp.status_code == 401
+    resp = client.get("/", headers={"Authorization": "Bearer secret"})
+    assert resp.status_code == 200

--- a/tests/unit/test_sdk.py
+++ b/tests/unit/test_sdk.py
@@ -1,0 +1,32 @@
+from llm_microservice.sdk.models import (
+    ChatMessage,
+    CompletionRequest,
+    CompletionResponse,
+    CompletionChoice,
+    UsageInfo,
+)
+
+
+def test_serialization_roundtrip():
+    req = CompletionRequest(
+        model="test", messages=[ChatMessage(role="user", content="hi")]
+    )
+    data = req.model_dump()
+    new_req = CompletionRequest.model_validate(data)
+    assert new_req == req
+
+    resp = CompletionResponse(
+        id="1",
+        object="chat.completion",
+        created=0,
+        model="test",
+        choices=[
+            CompletionChoice(
+                index=0, message=ChatMessage(role="assistant", content="ok")
+            )
+        ],
+        usage=UsageInfo(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+    data = resp.model_dump()
+    new_resp = CompletionResponse.model_validate(data)
+    assert new_resp == resp

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,13 @@
+from llm_microservice.utils import count_tokens, count_message_tokens
+
+
+def test_count_tokens():
+    assert count_tokens("hello world") == 2
+
+
+def test_count_message_tokens():
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "world"},
+    ]
+    assert count_message_tokens(messages) == 2


### PR DESCRIPTION
## Summary
- implement FastAPI service launching vLLM
- add Python SDK and utilities
- create Dockerfile and compose file
- document architecture and SDK usage
- add unit/integration tests and CI workflow

## Testing
- `make lint`
- `make test`
- `USE_MOCK_LLM=1 make ci`


------
https://chatgpt.com/codex/tasks/task_e_687817369a248333bc2912c68eddb1be