### PR TITLE
Fix workflow secret guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - run: pip install pytest httpx
+      - run: |
+          pip install ruff black mypy pydantic~=2.6 setuptools_scm \
+            pytest httpx docker  # docker is a no-op in mock but needed in real
       - run: make ci
 
   integration-real:
@@ -58,7 +60,9 @@ jobs:
         if: ${{ env.USE_REAL_LLM != '' }}
         with:
           python-version: '3.11'
-      - run: pip install pytest httpx docker
+      - run: |
+          pip install ruff black mypy pydantic~=2.6 setuptools_scm \
+            pytest httpx docker
         if: ${{ env.USE_REAL_LLM != '' }}
       - run: make ci
         if: ${{ env.USE_REAL_LLM != '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - run: pip install ruff black mypy setuptools_scm
+      # install pydantic for the mypy plugin
+      - run: pip install ruff black mypy pydantic~=2.6 setuptools_scm
       - run: make lint
 
   unit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,16 +41,23 @@ jobs:
       - run: make ci
 
   integration-real:
-    if: ${{ secrets.USE_REAL_LLM != '' }}
     needs: integration-mock
     runs-on: [self-hosted, gpu]
     env:
       USE_REAL_LLM: ${{ secrets.USE_REAL_LLM }}
     steps:
+      - name: Skip when secret is absent
+        if: ${{ env.USE_REAL_LLM == '' }}
+        run: |
+          echo "::notice::Integration-real skipped – secret USE_REAL_LLM not set."
+          exit 0
       - uses: actions/checkout@v4
+        if: ${{ env.USE_REAL_LLM != '' }}
       - uses: actions/setup-python@v5
+        if: ${{ env.USE_REAL_LLM != '' }}
         with:
           python-version: '3.11'
       - run: pip install pytest httpx docker
+        if: ${{ env.USE_REAL_LLM != '' }}
       - run: make ci
         if: ${{ env.USE_REAL_LLM != '' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,10 @@ requires-python = ">=3.11"
 license = {file = "LICENSE"}
 description = "LLM microservice with vLLM"
 readme = "README.md"
+dependencies = [
+    "pydantic~=2.6",
+    "httpx",
+]
 
 [project.optional-dependencies]
 server = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,10 @@ license = {file = "LICENSE"}
 description = "LLM microservice with vLLM"
 readme = "README.md"
 dependencies = [
-    "pydantic~=2.6",
+    "fastapi~=0.111",
     "httpx",
+    "pydantic~=2.6",
+    "starlette>=0.37,<0.38",  # FastAPI runtime
 ]
 
 [project.optional-dependencies]
@@ -48,3 +50,6 @@ Homepage = "https://example.com"
 [tool.pytest.ini_options]
 addopts = "-ra"
 pythonpath = ["src"]
+markers = [
+  "integration: mark for integration tests",
+]

--- a/src/llm_microservice/server/main.py
+++ b/src/llm_microservice/server/main.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 from typing import Awaitable, Callable, ParamSpec, TypeVar, cast
-from functools import wraps
+import functools
 import time
 from datetime import datetime
 from typing import Any, AsyncGenerator, Dict
@@ -52,9 +52,9 @@ R = TypeVar("R")
 
 
 def _log(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
-    """Middleware-style decorator that logs latency."""
+    """Decorator that logs latency and token counts without losing type info."""
 
-    @wraps(func)
+    @functools.wraps(func)
     async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         start = time.perf_counter()
         result: R = await func(*args, **kwargs)


### PR DESCRIPTION
## Summary
- remove job-level secret guard from `integration-real` job
- guard the integration-real steps using environment variable
- skip when the USE_REAL_LLM secret isn't set

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68783c95552c8333b1cb7c0200d8e9b6