### PR TITLE
Fix integration-real runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
   integration-real:
     needs: integration-mock
-    runs-on: [self-hosted, gpu]
+    runs-on: ubuntu-24.04
     env:
       USE_REAL_LLM: ${{ secrets.USE_REAL_LLM }}
     steps:


### PR DESCRIPTION
## Summary
- run integration-real on ubuntu-24.04 runner instead of self-hosted GPU

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687917604ff083338b272986027ad8bb