### PR TITLE
Release prep: docs polish and version 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
-
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
-### Added
-- First release of independent LLM micro-service using vLLM.
-- Breaking change vs previous in-app LLM.
-- Migration guide forthcoming.
+
+## [1.0.0] - YYYY-MM-DD
+- Added: stand-alone FastAPI + vLLM micro-service for Meta Llama-3-8B-Instruct.
+- Added: Python SDK (`llm_microservice.sdk`), async & sync.
+- Added: Dockerfile (CUDA 12.4) and `docker-compose.yaml` with GPU override.
+- Added: MkDocs site (`docs/**`) and ADR directory.
+- **Breaking**: All consumer apps must set `LLM_BASE_URL`; local LLM path removed.
+- Migration: step-by-step guide (env vars, SDK install, old API removal).
+- CI: new jobs `integration-mock` & `integration-real`; skip logic via `USE_REAL_LLM`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# LLM Microservice
+
+Welcome to the LLM microservice documentation.
+
+See the system design in [ADR 0001](/adr/0001-record-architecture/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,9 @@
 site_name: LLM Microservice
 nav:
+  - Home: index.md
   - Quickstart: quickstart.md
-  - Architecture: architecture.md
   - SDK: sdk.md
+  - Architecture: architecture.md
   - ADRs:
       - ADR 0001: adr/0001-record-architecture.md
 docs_dir: docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm_microservice"
-dynamic = ["version"]
+version = "1.0.0"
 requires-python = ">=3.11"
 license = {file = "LICENSE"}
 description = "LLM microservice with vLLM"
@@ -22,6 +22,9 @@ server = [
     "fastapi",
     "uvicorn[standard]",
     "vllm",
+]
+dev = [
+    "mkdocs-material~=9.5",
 ]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
## Summary
- prepare changelog for v1.0.0 release
- add docs index page and update mkdocs navigation
- bump project metadata to version 1.0.0 and add dev extras

## Testing
- `ruff check src tests docs`
- `black --check src tests docs`
- `mypy src`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68791c9e91048333836cc56dd2d015fd