### PR TITLE
Fix docker compose run instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,4 @@
-# --- LLM_microservice defaults -----------------
 MODEL_NAME=meta-llama/Meta-Llama-3-8B-Instruct
 GPU_MEMORY_UTILIZATION=0.85
 HF_HOME=/models/.cache
-# LLM_API_KEY=         # uncomment + set to protect the API
+# LLM_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
+# local overrides
 .env
 *.pyc
 .mypy_cache/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,6 @@ RUN pip3 install --no-cache-dir fastapi uvicorn[standard] vllm huggingface-hub h
 WORKDIR /app
 COPY . /app
 
-RUN pip3 install --no-cache-dir .[server]
+RUN pip3 install --no-cache-dir ".[server]"
 
 CMD ["tini", "-g", "uvicorn", "llm_microservice.server.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,7 @@
 
 ## Run with GPU
 ```bash
-docker compose up -d
+cp .env.example .env && docker compose up -d --build
 ```
 
 ## Run without GPU (mock)


### PR DESCRIPTION
## Summary
- fix Dockerfile quoting so `[server]` extra installs correctly
- keep .env file out of Git
- update quickstart instructions to create local `.env`
- trim example environment file

## Testing
- `make lint`
- `make test`
- `docker compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879414ee37c83339f2b3537fe4e2218