### PR TITLE
Fix Docker entrypoint and add CI health check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,28 @@ jobs:
           pip install .
       - run: make ci
 
-  integration-real:
+  build-docker:
     needs: integration-mock
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build image
+        run: docker build -t test-llm -f docker/Dockerfile .
+
+      - name: Smoke-test /health
+        run: |
+          docker run -d --rm -p 8000:8000 --name llm test-llm
+          for i in {1..30}; do
+            sleep 2
+            if curl -sf http://localhost:8000/health; then
+              echo "health OK"; docker stop llm; exit 0
+            fi
+          done
+          echo "healthcheck failed"; docker logs llm; docker stop llm; exit 1
+
+  integration-real:
+    needs: [build-docker]
     runs-on: ubuntu-24.04
     env:
       USE_REAL_LLM: ${{ secrets.USE_REAL_LLM }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,14 +55,14 @@ jobs:
 
       - name: Smoke-test /health
         run: |
-          docker run -d --rm -p 8000:8000 --name llm test-llm
+          docker run -d -p 8000:8000 --name llm test-llm
           for i in {1..30}; do
             sleep 2
             if curl -sf http://localhost:8000/health; then
-              echo "health OK"; docker stop llm; exit 0
+              echo "health OK"; docker rm -f llm; exit 0
             fi
           done
-          echo "healthcheck failed"; docker logs llm; docker stop llm; exit 1
+          echo "healthcheck failed"; docker logs llm; docker rm -f llm; exit 1
 
   integration-real:
     needs: [build-docker]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,15 +7,18 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/*
 RUN apt-get update && apt-get install -y tini && rm -rf /var/lib/apt/lists/*
 
+# ensure Python 3.11 is used for all installs
+RUN python3.11 -m pip install --upgrade pip
+
 ENV PYTHONUNBUFFERED=1 \
     HF_HOME=/models/.cache
 
-RUN pip3 install --no-cache-dir fastapi uvicorn[standard] vllm huggingface-hub httpx
+RUN python3.11 -m pip install --no-cache-dir fastapi uvicorn[standard] vllm huggingface-hub httpx
 
 WORKDIR /app
 COPY . /app
 
-RUN pip3 install --no-cache-dir ".[server]"
+RUN python3.11 -m pip install --no-cache-dir ".[server]"
 
 # tini as the init process
 ENTRYPOINT ["tini", "-g", "--"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,4 +17,8 @@ COPY . /app
 
 RUN pip3 install --no-cache-dir ".[server]"
 
-CMD ["tini", "-g", "uvicorn", "llm_microservice.server.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# tini as the init process
+ENTRYPOINT ["tini", "-g", "--"]
+
+# launch FastAPI via Uvicorn
+CMD ["uvicorn", "llm_microservice.server.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- fix tini usage in Dockerfile and use ENTRYPOINT/CMD
- run smoke tests for Docker image in CI

## Testing
- `make test`
- `USE_MOCK_LLM=1 pytest tests/integration -q`


------
https://chatgpt.com/codex/tasks/task_e_6879740aadd88333b0d59a7f92f1c8f1