### PR TITLE
Make quantization configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,6 @@ LLM_TAG=v1.5.0 # change to v1.6.0 on upgrade
 MODEL_NAME=meta-llama/Meta-Llama-3-8B-Instruct
 GPU_MEMORY_UTILIZATION=0.85
 HF_HOME=/models/.cache
+# QUANTIZATION=awq # optional: set to 'awq', 'gptq', or leave empty/None for standard loading
 
 LLM_API_KEY=

--- a/src/llm_microservice/server/main.py
+++ b/src/llm_microservice/server/main.py
@@ -33,6 +33,8 @@ logging.basicConfig(level=logging.INFO)
 MODEL_NAME = os.getenv("MODEL_NAME", "meta-llama/Meta-Llama-3-8B-Instruct")
 GPU_MEMORY_UTILIZATION = float(os.getenv("GPU_MEMORY_UTILIZATION", "0.85"))
 API_KEY = os.getenv("LLM_API_KEY")
+# quantization can be "awq", "gptq", or None for standard loading
+QUANTIZATION = os.getenv("QUANTIZATION") or None
 
 app = FastAPI()
 
@@ -95,7 +97,7 @@ class LLMEngine:
             model=MODEL_NAME,
             gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
             max_model_len=16384,
-            quantization="awq",
+            quantization=QUANTIZATION,
         )
 
     def generate(self, prompt: str, params: SamplingParams) -> Any:


### PR DESCRIPTION
## Summary
- read QUANTIZATION env var in `main.py`
- wire env var into `LLM` construction
- document optional QUANTIZATION in `.env.example`

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy src`
- `pytest -m "not integration" -q`

------
https://chatgpt.com/codex/tasks/task_e_687a202a38708333b9cf0d784d1bb4e1