### PR TITLE
Make quantization optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,6 @@ LLM_TAG=v1.5.0 # change to v1.6.0 on upgrade
 MODEL_NAME=meta-llama/Meta-Llama-3-8B-Instruct
 GPU_MEMORY_UTILIZATION=0.85
 HF_HOME=/models/.cache
+# QUANTIZATION=awq  # optional, one of: awq, gptq, ...; leave empty for standard weights
 
 LLM_API_KEY=

--- a/src/llm_microservice/server/main.py
+++ b/src/llm_microservice/server/main.py
@@ -33,6 +33,8 @@ logging.basicConfig(level=logging.INFO)
 MODEL_NAME = os.getenv("MODEL_NAME", "meta-llama/Meta-Llama-3-8B-Instruct")
 GPU_MEMORY_UTILIZATION = float(os.getenv("GPU_MEMORY_UTILIZATION", "0.85"))
 API_KEY = os.getenv("LLM_API_KEY")
+# optional quantization method, e.g. "awq" or "gptq"
+QUANTIZATION = os.getenv("QUANTIZATION")
 
 app = FastAPI()
 
@@ -91,12 +93,14 @@ class LLMEngine:
     def __init__(self) -> None:
         if LLM is None:
             raise RuntimeError("vLLM is not installed")
-        self.llm = LLM(
-            model=MODEL_NAME,
-            gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
-            max_model_len=16384,
-            quantization="awq",
-        )
+        kwargs = {
+            "model": MODEL_NAME,
+            "gpu_memory_utilization": GPU_MEMORY_UTILIZATION,
+            "max_model_len": 16384,
+        }
+        if QUANTIZATION:
+            kwargs["quantization"] = QUANTIZATION
+        self.llm = LLM(**kwargs)
 
     def generate(self, prompt: str, params: SamplingParams) -> Any:
         return self.llm.generate([prompt], params)[0]


### PR DESCRIPTION
## Summary
- read optional `QUANTIZATION` from env
- pass quantization to `LLM` only when set
- document optional QUANTIZATION in `.env.example`

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy src`
- `pytest -m "not integration" -q`


------
https://chatgpt.com/codex/tasks/task_e_687a202a38708333b9cf0d784d1bb4e1