### PR TITLE
Fix staging deploy workflow

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,0 +1,19 @@
+name: Deploy to staging
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  staging-deploy:
+    if: ${{ secrets.STAGING_HOST != '' && secrets.STAGING_USER != '' && secrets.STAGING_SSH_KEY != '' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.STAGING_SSH_KEY }}
+      - name: Deploy
+        run: ssh -o StrictHostKeyChecking=no ${{ secrets.STAGING_USER }}@${{ secrets.STAGING_HOST }} 'echo Deploying'


### PR DESCRIPTION
## Summary
- add a staging deploy workflow
- guard the deploy job if SSH secrets are missing

## Testing
- `make lint`
- `make test`
- `act -n -W .github/workflows/staging-deploy.yml -j staging-deploy` *(fails: couldn't get a valid docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_687f52a9eb2c833399aa6b38b3bfcc2b